### PR TITLE
setting app count to a higher limit

### DIFF
--- a/component/app-store-ui/src/app/apis/apis.service.ts
+++ b/component/app-store-ui/src/app/apis/apis.service.ts
@@ -98,7 +98,9 @@ export class ApisService {
     }
 
     getAvailableApplications(): Observable<any> {
-        return this.http.get<any>(ApiEndpoints.apis.availableApp);
+        const searchParams = new HttpParams()
+            .append('limit', "1000");
+        return this.http.get<any>(ApiEndpoints.apis.availableApp, { params: searchParams });
     }
 
     getSelectedAppDetails(appId: string): Observable<ApplicationDetails> {


### PR DESCRIPTION
because WSO2 API Manager does not support pagination nor wildcard search of Apps.

https://docs.wso2.com/display/AM250/apidocs/store/index.html#!/operations#ApplicationCollection#applicationsGet